### PR TITLE
43051588: fix scrollarea display type

### DIFF
--- a/packages/pkg.scrollarea/ScrollArea.tsx
+++ b/packages/pkg.scrollarea/ScrollArea.tsx
@@ -15,7 +15,7 @@ const ScrollArea = ({ className, children, ref, ...props }: ScrollAreaProps) => 
       ref={ref}
       className={cn('relative overflow-hidden', className)}
     >
-      <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit] [&>div]:!block">
         {children}
       </ScrollAreaPrimitive.Viewport>
       <ScrollBar />

--- a/packages/pkg.scrollarea/package.json
+++ b/packages/pkg.scrollarea/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xipkg/scrollarea",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "license": "MIT",


### PR DESCRIPTION
исправил проблему отображения viewport для scrollarea
по умолчанию там стоит display: table что не позволяло делать обрезку текста в дочерних элементах

есть [issue](https://github.com/radix-ui/primitives/issues/926) проблема вроде как не решена.