### PR TITLE
fix(pkg.emojipicker): fix tooltip in emojipicker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24964,7 +24964,7 @@
     },
     "packages/pkg.emoji.picker": {
       "name": "@xipkg/emojipicker",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "license": "MIT",
       "dependencies": {
         "@xipkg/button": "^3.1.7",

--- a/packages/pkg.emoji.picker/EmojiPickerPopup.tsx
+++ b/packages/pkg.emoji.picker/EmojiPickerPopup.tsx
@@ -127,7 +127,11 @@ export const EmojiPickerPopup = ({ recentEmojis, onEmojiSelect }: TEmojiPopup) =
 
   return (
     <div className="flex h-[296px] w-[276px]">
-      <div className="bg-gray-5 dark:bg-gray-90 flex flex-col gap-2 rounded-l-lg p-2">
+      <div
+        tabIndex={0}
+        aria-label="Категории эмодзи"
+        className="bg-gray-5 dark:bg-gray-90 flex flex-col gap-2 rounded-l-lg p-2"
+      >
         <TooltipProvider>
           {emojiCategoriesIcons.map(({ icon: Icon, name }, index) => {
             return (
@@ -149,7 +153,7 @@ export const EmojiPickerPopup = ({ recentEmojis, onEmojiSelect }: TEmojiPopup) =
                     />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent side="right" className="z-99">
+                <TooltipContent side="left" className="z-99">
                   <p>{name}</p>
                 </TooltipContent>
               </Tooltip>

--- a/packages/pkg.emoji.picker/package.json
+++ b/packages/pkg.emoji.picker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@xipkg/emojipicker",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.mts",


### PR DESCRIPTION
fix [#160](https://github.com/xi-effect/xi.progress/issues/160)

Поправила появление подсказки. Установила tabIndex={0} на див с категориями эмодзи  - это лучшее решение из возможных плохих. Таким образом я сохранила табиндекс на кнопках, добавила accessibility на контейнер. Были две альтернативы: убрать табиндекс на кнопках, что убирает accessibility полностью или переписать Tooltip.